### PR TITLE
Adding duplicate event filtering from Event Streams

### DIFF
--- a/src/CloudAbstractions.csproj
+++ b/src/CloudAbstractions.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.6" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.2.0" />


### PR DESCRIPTION
Filtering out duplicate Events from an Event Stream using a 60 second timeout for each event ID