### PR TITLE
Fixing function name for Pool Start Task

### DIFF
--- a/src/Abstractions/IJobScheduler.cs
+++ b/src/Abstractions/IJobScheduler.cs
@@ -7,7 +7,7 @@ namespace BaseCap.CloudAbstractions.Abstractions
     public interface IJobScheduler : IDisposable
     {
         Task SetupAsync();
-        Task SetPoolStartTaskAndRebootAsync(string poolId, string commandLine);
+        Task SetPoolStartTaskAsync(string poolId, string commandLine);
         Task CreateJobAsync(Abstractions.CloudJob jobInput, CloudJobTask taskInput, string poolId);
         Task CreateOrUpdateCloudJobApplicationAsync(IBlobStorage sourceBlobStorage, CloudJobApplication application, IEnumerable<string> poolNames);
         Task<bool> DoesApplicationPackageExistAsync(string appId, string version);

--- a/src/Implementations/AzureBatch.cs
+++ b/src/Implementations/AzureBatch.cs
@@ -77,7 +77,7 @@ namespace BaseCap.CloudAbstractions.Implementations
             _management = new BatchManagementClient(new TokenCredentials(token, "Bearer")) { SubscriptionId = _subscriptionId };
         }
 
-        public async Task SetPoolStartTaskAndRebootAsync(string poolId, string commandLine)
+        public async Task SetPoolStartTaskAsync(string poolId, string commandLine)
         {
             Pool currentPool = await _management.Pool.GetAsync(_resourceGroup, _batchAccountName, poolId);
             Pool poolUpdate = new Pool(id: currentPool.Id)


### PR DESCRIPTION
Fixing function name for Pool Start Task; it had "Reboot" in it when the function did not cause a reboot