### PR TITLE
Fixing BlobItem Directory Name

### DIFF
--- a/src/Abstractions/BlobItem.cs
+++ b/src/Abstractions/BlobItem.cs
@@ -56,7 +56,7 @@ namespace BaseCap.CloudAbstractions.Abstractions
 
         internal BlobItem(CloudBlobDirectory directory)
         {
-            Name = Path.GetDirectoryName(directory.Prefix);
+            Name = Path.GetFileName(Path.GetDirectoryName(directory.Prefix));
             RelativePath = directory.Prefix;
             FullPath = directory.Uri;
             ContainerName = directory.Container.Name;


### PR DESCRIPTION
Fixing BlobItem Name when created from a directory; before, Name would actually be the full relative path since GetDirectoryName only formatted the path correctly. Now, we format the name and then retrieve the folder name