### PR TITLE
Fixing AppInsights logger constructor

### DIFF
--- a/src/Implementations/Azure/AppInsightsLogger.cs
+++ b/src/Implementations/Azure/AppInsightsLogger.cs
@@ -14,9 +14,9 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
         private readonly TelemetryClient _logger;
 
         /// <inheritdoc />
-        public AppInsightsLogger()
+        public AppInsightsLogger(TelemetryConfiguration configuration)
         {
-            _logger = new TelemetryClient(TelemetryConfiguration.Active);
+            _logger = new TelemetryClient(configuration);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixing App Insights logger constructor to use passed in Configuration instead of the deprecated `Active` singleton