### PR TITLE
Fixing interface bug on HyperLogLog

### DIFF
--- a/src/Abstractions/IHyperLogLog.cs
+++ b/src/Abstractions/IHyperLogLog.cs
@@ -8,6 +8,11 @@ namespace BaseCap.CloudAbstractions.Abstractions
     public interface IHyperLogLog
     {
         /// <summary>
+        /// Initializes the connection
+        /// </summary>
+        Task SetupAsync();
+
+        /// <summary>
         /// Checks if the provided key is unique in the set
         /// </summary>
         /// <param name="key">The entry to check for uniqueness</param>

--- a/src/Implementations/Redis/RedisHyperLogLog.cs
+++ b/src/Implementations/Redis/RedisHyperLogLog.cs
@@ -6,7 +6,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
     /// <summary>
     /// A connection to a redis hyperloglog
     /// </summary>
-    public class RedisHyperLogLog : RedisBase
+    public class RedisHyperLogLog : RedisBase, IHyperLogLog
     {
         private readonly string _logName;
 
@@ -17,6 +17,12 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             : base(endpoint, password, useSsl, "HyperLogLog", "[default]", logger)
         {
             _logName = logName;
+        }
+
+        /// <inheritdoc />
+        Task IHyperLogLog.SetupAsync()
+        {
+            return base.SetupAsync();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixing bug where the RedisHyperLogLog implementation did not have a Setup call and did not declare that it implements the IHyperLogLog interface