### PR TITLE
Adding DoesHashFieldExistAsync function to RedisCache

### DIFF
--- a/src/Abstractions/ICache.cs
+++ b/src/Abstractions/ICache.cs
@@ -83,6 +83,14 @@ namespace BaseCap.CloudAbstractions.Abstractions
         Task<long> IncrementHashKeyAsync(string hashKey, string fieldKey, int increment);
 
         /// <summary>
+        /// Checks if the given field exists in the specified hash set
+        /// </summary>
+        /// <param name="hashKey">The key to the hashset</param>
+        /// <param name="fieldKey">The field name in the hashset</param>
+        /// <returns>Returns true if the field exists; otherwise, returns false</returns>
+        Task<bool> DoesHashFieldExistAsync(string hashKey, string fieldKey);
+
+        /// <summary>
         /// Retrieves specific field values from the hashset
         /// </summary>
         /// <param name="hashKey">The key to the hashset</param>

--- a/src/Implementations/Redis/RedisCache.cs
+++ b/src/Implementations/Redis/RedisCache.cs
@@ -142,6 +142,12 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         }
 
         /// <inheritdoc />
+        public Task<bool> DoesHashFieldExistAsync(string hashKey, string fieldKey)
+        {
+            return _database.HashExistsAsync(hashKey, fieldKey);
+        }
+
+        /// <inheritdoc />
         public async Task<IEnumerable<long?>> GetHashKeyFieldValuesAsync(string hashKey, params string[] fields)
         {
             RedisValue[] values = new RedisValue[fields.Length];


### PR DESCRIPTION
Adding function DoesHashFieldExistAsync to check if a given field exists in the specified hashset