### PR TITLE
Fixing RedisBase intialization naming

### DIFF
--- a/src/Abstractions/IQueue.cs
+++ b/src/Abstractions/IQueue.cs
@@ -9,7 +9,12 @@ namespace BaseCap.CloudAbstractions.Abstractions
     public interface IQueue
     {
         /// <summary>
-        /// Constructs the underlying stream connection
+        /// Constructs the underlying stream connection for write connections
+        /// </summary>
+        Task SetupAsync();
+
+        /// <summary>
+        /// Constructs the underlying stream connection for read connections
         /// </summary>
         Task SetupAsync(Func<QueueMessage, Task<bool>> onMessageReceived);
 

--- a/src/Implementations/Azure/AzureQueueStorage.cs
+++ b/src/Implementations/Azure/AzureQueueStorage.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace BaseCap.CloudAbstractions.Implementations
+namespace BaseCap.CloudAbstractions.Implementations.Azure
 {
     /// <summary>
     /// Provides a connection for data be passed to and from Azure Blob Queue Storage
@@ -95,6 +95,12 @@ namespace BaseCap.CloudAbstractions.Implementations
             _onMessageReceived = onMessageReceived;
             _keepReading = true;
             _runner = Task.Run(ReadFromQueueAsync);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public Task SetupAsync()
+        {
             return Task.CompletedTask;
         }
 

--- a/src/Implementations/Azure/Secure/AzureEncryptedQueueStorage.cs
+++ b/src/Implementations/Azure/Secure/AzureEncryptedQueueStorage.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BaseCap.CloudAbstractions.Implementations.Secure
+namespace BaseCap.CloudAbstractions.Implementations.Azure.Secure
 {
     /// <summary>
     /// Provides seamless encryption and decryption for data be passed to and from Azure Blob Queue Storage

--- a/src/Implementations/Redis/RedisBase.cs
+++ b/src/Implementations/Redis/RedisBase.cs
@@ -184,13 +184,13 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             ResetConnection();
         }
 
-        protected Task SetupAsync()
+        protected Task InitializeAsync()
         {
             CreateConnection();
             return Task.CompletedTask;
         }
 
-        protected async Task ShutdownAsync()
+        protected async Task CleanupAsync()
         {
             _database = null;
             await _subscription.UnsubscribeAllAsync().ConfigureAwait(false);

--- a/src/Implementations/Redis/RedisCache.cs
+++ b/src/Implementations/Redis/RedisCache.cs
@@ -21,9 +21,9 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         {
         }
 
-        Task ICache.SetupAsync()
+        public Task SetupAsync()
         {
-            return base.SetupAsync();
+            return base.InitializeAsync();
         }
 
         /// <inheritdoc />

--- a/src/Implementations/Redis/RedisHyperLogLog.cs
+++ b/src/Implementations/Redis/RedisHyperLogLog.cs
@@ -28,9 +28,9 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         }
 
         /// <inheritdoc />
-        Task IHyperLogLog.SetupAsync()
+        public Task SetupAsync()
         {
-            return base.SetupAsync();
+            return base.InitializeAsync();
         }
 
         /// <inheritdoc />

--- a/src/Implementations/Redis/RedisPubSubReceiver.cs
+++ b/src/Implementations/Redis/RedisPubSubReceiver.cs
@@ -24,14 +24,14 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         public async Task SetupAsync(Func<string, Task> handler)
         {
             _handler = handler;
-            await base.SetupAsync().ConfigureAwait(false);
+            await base.InitializeAsync().ConfigureAwait(false);
             base.Subscribe(_channel, ReceiveHandler);
         }
 
         /// <inheritdoc />
-        Task INotificationReceiver.ShutdownAsync()
+        public Task ShutdownAsync()
         {
-            return base.ShutdownAsync();
+            return base.CleanupAsync();
         }
 
         protected override void ResetConnection()

--- a/src/Implementations/Redis/RedisPubSubSender.cs
+++ b/src/Implementations/Redis/RedisPubSubSender.cs
@@ -19,9 +19,9 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         }
 
         /// <inheritdoc />
-        Task INotificationSender.SetupAsync()
+        public Task SetupAsync()
         {
-            return base.SetupAsync();
+            return base.InitializeAsync();
         }
 
         /// <inheritdoc />

--- a/src/Implementations/Redis/RedisQueueStorage.cs
+++ b/src/Implementations/Redis/RedisQueueStorage.cs
@@ -36,10 +36,16 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         public async Task SetupAsync(Func<QueueMessage, Task<bool>> onMessageReceived)
         {
             _onMessageReceived = onMessageReceived;
-            await base.SetupAsync().ConfigureAwait(false);
+            await base.InitializeAsync().ConfigureAwait(false);
             base.Subscribe(_channelName, InternalOnMessageReceived);
             _keepPolling = true;
             _pollingFallback = Task.Run(PollingFallbackAsync);
+        }
+
+        /// <inheritdoc />
+        public Task SetupAsync()
+        {
+            return base.InitializeAsync();
         }
 
         /// <inheritdoc />
@@ -47,7 +53,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         {
             _keepPolling = false;
             await Task.WhenAny(new [] { _pollingFallback, Task.Delay(TimeSpan.FromSeconds(3)) }).ConfigureAwait(false);
-            await base.ShutdownAsync().ConfigureAwait(false);
+            await base.CleanupAsync().ConfigureAwait(false);
         }
 
         protected override void ResetConnection()

--- a/src/Implementations/Redis/RedisStreamReader.cs
+++ b/src/Implementations/Redis/RedisStreamReader.cs
@@ -35,9 +35,9 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             _consumerName = consumerName;
         }
 
-        async Task IEventStreamReader.SetupAsync()
+        public async Task SetupAsync()
         {
-            await base.SetupAsync().ConfigureAwait(false);
+            await base.InitializeAsync().ConfigureAwait(false);
             await base.CreateStreamIfNecessaryAsync(_streamName).ConfigureAwait(false);
             await base.CreateStreamConsumerGroupIfNecessaryAsync(_streamName, _consumerGroup).ConfigureAwait(false);
         }

--- a/src/Implementations/Redis/RedisStreamSender.cs
+++ b/src/Implementations/Redis/RedisStreamSender.cs
@@ -27,16 +27,16 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         }
 
         /// <inheritdoc />
-        async Task IEventStreamWriter.SetupAsync()
+        public async Task SetupAsync()
         {
-            await base.SetupAsync().ConfigureAwait(false);
+            await base.InitializeAsync().ConfigureAwait(false);
             await base.CreateStreamIfNecessaryAsync(_streamName).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public Task CloseAsync()
         {
-            return base.ShutdownAsync();
+            return base.CleanupAsync();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixing RedisBase intialization naming to not clash with implementing interfaces