### PR TITLE
Fixing quick bug in Encrypted Redis Stream

### DIFF
--- a/src/Implementations/Redis/Secure/EncryptedRedisStreamReader.cs
+++ b/src/Implementations/Redis/Secure/EncryptedRedisStreamReader.cs
@@ -44,7 +44,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
                 decryptedEntries.Add(entries[id].Name, new NameValueEntry(entries[id].Name, plaintext));
             }
 
-            await base.ProcessMessagesAsync(entries, onMessagesReceived).ConfigureAwait(false);
+            await base.ProcessMessagesAsync(decryptedEntries, onMessagesReceived).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Fixing bug where we sent the encrypted stream messages through instead of the decrypted ones