### PR TITLE
Adding null checks for data senders

### DIFF
--- a/src/Implementations/Redis/RedisPubSubSender.cs
+++ b/src/Implementations/Redis/RedisPubSubSender.cs
@@ -1,4 +1,5 @@
 using BaseCap.CloudAbstractions.Abstractions;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -26,8 +27,13 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         /// <inheritdoc />
         public async Task SendNotificationAsync(object notification)
         {
-            string value = GetNotificationValue(notification);
-            await _subscription.PublishAsync(_channel, value).ConfigureAwait(false);
+            string serialized = GetNotificationValue(notification);
+            if (string.IsNullOrWhiteSpace(serialized))
+            {
+                throw new InvalidOperationException("Cannot send empty message");
+            }
+
+            await _subscription.PublishAsync(_channel, serialized).ConfigureAwait(false);
         }
 
         internal virtual string GetNotificationValue(object notification)

--- a/src/Implementations/Redis/RedisStreamSender.cs
+++ b/src/Implementations/Redis/RedisStreamSender.cs
@@ -1,5 +1,6 @@
 using BaseCap.CloudAbstractions.Abstractions;
 using StackExchange.Redis;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -48,6 +49,11 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         public async Task SendEventDataAsync(object obj, string partition)
         {
             string data = SerializeObject(obj);
+            if (string.IsNullOrWhiteSpace(data))
+            {
+                throw new InvalidOperationException("Cannot send empty message");
+            }
+
             await _database.StreamAddAsync(_streamName, DATA_FIELD, data).ConfigureAwait(false);
         }
 
@@ -62,6 +68,11 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         {
             NameValueEntry[] entries = msgs.Select(m => new NameValueEntry(DATA_FIELD, SerializeObject(m)))
                                             .ToArray();
+            if (entries.Any() == false)
+            {
+                throw new InvalidOperationException("Cannot send empty message");
+            }
+
             return _database.StreamAddAsync(_streamName, entries);
         }
     }


### PR DESCRIPTION
Adding null and empty checks to all senders to ensure we don't add blank messages to cloud services