### PR TITLE
Fixing bug with ambiguous function call

### DIFF
--- a/src/Abstractions/IEventStreamWriter.cs
+++ b/src/Abstractions/IEventStreamWriter.cs
@@ -19,19 +19,6 @@ namespace BaseCap.CloudAbstractions.Abstractions
         Task CloseAsync();
 
         /// <summary>
-        /// Sends a single event to the eventing system on the specified partition
-        /// </summary>
-        /// <param name="obj">The object to send to the system</param>
-        /// <param name="partition">The event partition to send on</param>
-        Task SendEventDataAsync(object obj, string partition);
-
-        /// <summary>
-        /// Sends a single event to the eventing system
-        /// </summary>
-        /// <param name="obj">The object to send to the system</param>
-        Task SendEventDataAsync(object obj);
-
-        /// <summary>
         /// Sends a batch of objects to the eventing system on the specified partition
         /// </summary>
         /// <param name="objs">The object batch to send to the system</param>

--- a/src/Implementations/Azure/AzureEventHubWriter.cs
+++ b/src/Implementations/Azure/AzureEventHubWriter.cs
@@ -62,17 +62,6 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
         }
 
         /// <summary>
-        /// Sends the specified object as an event into the specified partition
-        /// </summary>
-        public async Task SendEventDataAsync(object obj, string partition)
-        {
-            using (EventData data = await GetEventDataAsync(obj).ConfigureAwait(false))
-            {
-                await _client.SendAsync(data, partition).ConfigureAwait(false);
-            }
-        }
-
-        /// <summary>
         /// Sends the batch of objects as separate events into the specified partition
         /// </summary>
         public async Task SendEventDataAsync(IList<object> msgs, string partition)
@@ -88,14 +77,6 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
                 await _client.SendAsync(messages, partition);
             }
             while (data.Count > 0);
-        }
-
-        public async Task SendEventDataAsync(object obj)
-        {
-            using (EventData data = await GetEventDataAsync(obj).ConfigureAwait(false))
-            {
-                await _client.SendAsync(data).ConfigureAwait(false);
-            }
         }
 
         public async Task SendEventDataAsync(IList<object> msgs)

--- a/src/Implementations/Redis/RedisStreamSender.cs
+++ b/src/Implementations/Redis/RedisStreamSender.cs
@@ -40,24 +40,6 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         }
 
         /// <inheritdoc />
-        public Task SendEventDataAsync(object obj)
-        {
-            return SendEventDataAsync(obj, string.Empty);
-        }
-
-        /// <inheritdoc />
-        public async Task SendEventDataAsync(object obj, string partition)
-        {
-            string data = SerializeObject(obj);
-            if (string.IsNullOrWhiteSpace(data))
-            {
-                throw new InvalidOperationException("Cannot send empty message");
-            }
-
-            await _database.StreamAddAsync(_streamName, DATA_FIELD, data).ConfigureAwait(false);
-        }
-
-        /// <inheritdoc />
         public Task SendEventDataAsync(IList<object> msgs)
         {
             return SendEventDataAsync(msgs, string.Empty);


### PR DESCRIPTION
Fixing bug where the function call to add a single event to the stream would prevent the function taking in an enumerable from being called due to precedence of objects