### PR TITLE
Adding redis consumer-group-less stream reading in encrypted clients

### DIFF
--- a/src/Implementations/Redis/Secure/EncryptedRedisStreamReader.cs
+++ b/src/Implementations/Redis/Secure/EncryptedRedisStreamReader.cs
@@ -31,6 +31,20 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
         }
 
         /// <inheritdoc />
+        public EncryptedRedisStreamReader(
+            byte[] encryptionKey,
+            IEnumerable<string> endpoints,
+            string password,
+            bool useSsl,
+            string streamName,
+            string consumerName,
+            ILogger logger)
+            : base(endpoints, password, useSsl, streamName, consumerName, logger)
+        {
+            _encryptionKey = encryptionKey;
+        }
+
+        /// <inheritdoc />
         internal override async Task<List<EventMessage>> ProcessMessagesAsync(StreamEntry[] entries)
         {
             List<EventMessage> messages = await base.ProcessMessagesAsync(entries);


### PR DESCRIPTION
Adding redis consumer-group-less stream reading in encrypted clients