### PR TITLE
Fixing SetupDotnet version in YAML

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v1.4.0
         with:
           dotnet-version: '3.0.100'
           source-url: https://nuget.pkg.github.com/basecap-analytics/index.json
@@ -22,4 +22,4 @@ jobs:
         run: dotnet pack -c Release --include-symbols
       - name: Publish Package
         working-directory: ./src
-        run: dotnet nuget push ./src/bin/Release/*.nupkg --source "github"
+        run: dotnet nuget push ./src/bin/Release/*.nupkg


### PR DESCRIPTION
Fixing SetupDotnet version in YAML to use the latest 1.4 version for nuget pushing to work