### PR TITLE
Adding Async Enumerable support to Redis

### DIFF
--- a/src/Abstractions/ICache.cs
+++ b/src/Abstractions/ICache.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using StackExchange.Redis;
 
 namespace BaseCap.CloudAbstractions.Abstractions
 {
@@ -121,6 +123,16 @@ namespace BaseCap.CloudAbstractions.Abstractions
         Task<bool> SetHashFieldAsync(string hashKey, string fieldKey, string value, bool waitForResponse = false);
 
         /// <summary>
+        /// Appends a value to the end of a Hash Field
+        /// </summary>
+        /// <param name="hashKey">The key to the hashset</param>
+        /// <param name="fieldKey">The field name in the hashset</param>
+        /// <param name="value">The value to put into the field</param>
+        /// <param name="cancellation">A Cancellation Token to cancel the request</param>
+        /// <returns>Returns true if the value was set; otherwise, returns false</returns>
+        Task<bool> AppendHashFieldAsync(string hashKey, string fieldKey, string value, CancellationToken cancellation);
+
+        /// <summary>
         /// Retrieves the specified field value of a hashset
         /// </summary>
         /// <param name="hashKey">The key to the hashset</param>
@@ -144,6 +156,13 @@ namespace BaseCap.CloudAbstractions.Abstractions
         Task<IEnumerable<long?>> GetHashKeyFieldValuesAsync(string hashKey, params string[] fields);
 
         /// <summary>
+        /// Retrieves an enumerable over all entries in the hash set
+        /// </summary>
+        /// <param name="hashKey">The key to the hashset</param>
+        /// <returns>Returns an enumerable to the hash entries</returns>
+        IAsyncEnumerable<HashEntry> GetHashEntriesEnumerable(string hashKey);
+
+        /// <summary>
         /// Adds a value to a set
         /// </summary>
         /// <param name="setName">The set name</param>
@@ -158,6 +177,13 @@ namespace BaseCap.CloudAbstractions.Abstractions
         /// <param name="setName">The set name</param>
         /// <returns>Returns an enumeration of the members</param>
         Task<IEnumerable<string>> GetSetMembersAsync(string setName);
+
+        /// <summary>
+        /// Iterate over every member of a Set
+        /// </summary>
+        /// <param name="setName">The set name</param>
+        /// <returns>Returns an async enumerable of the members</returns>
+        IAsyncEnumerable<RedisValue> GetSetMembersEnumerable(string setName);
 
         /// <summary>
         /// Increments the score of a sorted set member by the increment value
@@ -177,5 +203,12 @@ namespace BaseCap.CloudAbstractions.Abstractions
         /// <param name="sortDesc">Flag indicating if the retrieval should be for the highest score (true) or lowest score (false)</param>
         /// <returns>Returns a sorted enumeration of the members with their scores</param>
         Task<IEnumerable<KeyValuePair<string, double>>> GetSortedSetMembersAsync(string setName, int count, bool sortDesc);
+
+        /// <summary>
+        /// Retrieves an enumerator over the unordered members from a sorted set
+        /// </summary>
+        /// <param name="setName">The sorted set name</param>
+        /// <returns>Returns an enumerable to the unsorted members</returns>
+        IAsyncEnumerable<SortedSetEntry> GetSortedSetMembersEnumerable(string setName);
     }
 }

--- a/src/CloudAbstractions.csproj
+++ b/src/CloudAbstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>BaseCap.CloudAbstractions</AssemblyName>
     <AssemblyTitle>BaseCap Analytics Cloud Abstractions Package</AssemblyTitle>
     <AssemblyCompany>BaseCap Analytics</AssemblyCompany>
@@ -23,14 +23,14 @@
     <PackageReference Include="BaseCap.Security" Version="2.1.180207.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
-    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.4" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.6" />
     <PackageReference Include="MongoDB.Driver" Version="2.10.1" />
     <PackageReference Include="Sendgrid" Version="9.12.6" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.0-preview.23" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adding Async Enumerable support to Redis class to deal with Redis Cursors and not needing to pull whole sets and hashes into memory at once