### PR TITLE
Fixing RabbitMQ exchange variable

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
           dotnet-version: '3.0.100'
       - name: Build Package
         working-directory: ./src
-        run: dotnet pack -c Release --version-suffix "${GITHUB_SHA::7}" --include-symbols
+        run: dotnet pack -c Release --version-suffix "${GITHUB_RUN_NUMBER}" -p:VersionSuffix=${GITHUB_RUN_NUMBER} --include-symbols
       - name: Publish Package
         working-directory: ./src
         run: dotnet nuget push ./bin/Release/*.nupkg -k ${{ secrets.NuGet_API_Key }} -s "https://www.myget.org/F/bca/api/v2/package"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,4 +13,4 @@ jobs:
           dotnet-version: '3.0.100'
       - name: Build Package
         working-directory: ./src
-        run: dotnet pack -c Release --version-suffix "${GITHUB_SHA::7}" --include-symbols
+        run: dotnet pack -c Release --version-suffix "${GITHUB_RUN_NUMBER}" -p:VersionSuffix=${GITHUB_RUN_NUMBER} --include-symbols

--- a/src/CloudAbstractions.csproj
+++ b/src/CloudAbstractions.csproj
@@ -11,9 +11,9 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://raw.githubusercontent.com/basecap-analytics/CloudAbstractions/master/LICENSE</PackageLicenseUrl>
     <Copyright>Copyright 2018 (c) BaseCap Analytics. All rights reserved.</Copyright>
-    <Version Condition="'$(Configuration)'!='Release'">99.99.$([System.DateTime]::Now.ToString(yyMM)).$([System.DateTime]::Now.ToString(dd))</Version>
-    <Version Condition="'$(Configuration)'=='Release'">4.$([System.DateTime]::Now.ToString(yyMM)).$([System.DateTime]::Now.ToString(dd))</Version>
-    <VersionSuffix Condition="'$(VersionSuffix)'!=''">$(VersionSuffix)</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)'==''">1</VersionSuffix>
+    <Version Condition="'$(Configuration)'!='Release'">99.$([System.DateTime]::Now.ToString(yyMM)).$([System.DateTime]::Now.ToString(dd)).$(VersionSuffix)</Version>
+    <Version Condition="'$(Configuration)'=='Release'">4.$([System.DateTime]::Now.ToString(yyMM)).$([System.DateTime]::Now.ToString(dd)).$(VersionSuffix)</Version>
     <IncludeSymbols>True</IncludeSymbols>
     <IncludeSource>True</IncludeSource>
     <LangVersion>preview</LangVersion>

--- a/src/Implementations/RabbitMq/RabbitQueueManager.cs
+++ b/src/Implementations/RabbitMq/RabbitQueueManager.cs
@@ -45,7 +45,7 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
             model = connection.CreateModel();
         }
 
-        private static void EnsureQueueExists(IConnection connection, IModel model, string exchange, string queue)
+        private static void EnsureQueueExists(IConnection connection, IModel model, string queue)
         {
             if (connection == null)
             {
@@ -55,25 +55,18 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
             {
                 throw new ArgumentNullException(nameof(model));
             }
-            else if (string.IsNullOrWhiteSpace(exchange))
-            {
-                throw new ArgumentNullException(nameof(exchange));
-            }
             else if (string.IsNullOrWhiteSpace(queue))
             {
                 throw new ArgumentNullException(nameof(queue));
             }
 
-            model.ExchangeDeclare(exchange, "amq.direct", true, false); // Make sure our exchange exists
             model.QueueDeclare(queue, true, false, false); // Make sure our queue exists
-            model.QueueBind(queue, exchange, queue); // Make sure the queue is bound to the exchange
             model.BasicQos(0, 1, false); // Make sure the exchange waits for a message reader to ack that it completed processing before giving it more messages
         }
 
         /// <summary>
         /// Creates a new Queue Listener to listen for plaintext messages
         /// </summary>
-        /// <param name="exchange">The routing exchange to send to</param>
         /// <param name="queue">The queue to send the message to</param>
         /// <param name="username">The username to connect to the queue with</param>
         /// <param name="password">The password to authenticate to the queue with</param>
@@ -81,7 +74,6 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
         /// <param name="virtualHost">The path to route messages in multi-use server</param>
         /// <returns>Returns an IQueueListener capable of receiving plaintext messages</returns>
         public static IQueueListener CreateListener(
-            string exchange,
             string queue,
             string username,
             string password,
@@ -89,14 +81,13 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
             string virtualHost)
         {
             CreateRabbitConnection(username, password, virtualHost, host, out IConnection connection, out IModel model);
-            EnsureQueueExists(connection, model, exchange, queue);
+            EnsureQueueExists(connection, model, queue);
             return new RabbitQueueListener(connection, model, queue);
         }
 
         /// <summary>
         /// Creates a new Queue Listener to listen for encrypted messages
         /// </summary>
-        /// <param name="exchange">The routing exchange to send to</param>
         /// <param name="queue">The queue to send the message to</param>
         /// <param name="username">The username to connect to the queue with</param>
         /// <param name="password">The password to authenticate to the queue with</param>
@@ -105,7 +96,6 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
         /// <param name="encryptionKey">The encryption key used to encrypt messages</param>
         /// <returns>Returns an IQueueListener capable of receiving encrypted messages</returns>
         public static IQueueListener CreateSecureListener(
-            string exchange,
             string queue,
             string username,
             string password,
@@ -114,14 +104,13 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
             byte[] encryptionKey)
         {
             CreateRabbitConnection(username, password, virtualHost, host, out IConnection connection, out IModel model);
-            EnsureQueueExists(connection, model, exchange, queue);
+            EnsureQueueExists(connection, model, queue);
             return new RabbitSecureQueueListener(connection, model, queue, encryptionKey);
         }
 
         /// <summary>
         /// Creates a new Queue Sender to send plaintext messages
         /// </summary>
-        /// <param name="exchange">The routing exchange to send to</param>
         /// <param name="queue">The queue to send the message to</param>
         /// <param name="username">The username to connect to the queue with</param>
         /// <param name="password">The password to authenticate to the queue with</param>
@@ -131,7 +120,6 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
         /// <param name="encryptionKey">The key used to encrypt the message</param>
         /// <returns>Returns an IQueueSender capable of sending plaintext messages</returns>
         public static IQueueSender CreateSender(
-            string exchange,
             string queue,
             string username,
             string password,
@@ -140,14 +128,13 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
             bool confirmMessageSent)
         {
             CreateRabbitConnection(username, password, virtualHost, host, out IConnection connection, out IModel model);
-            EnsureQueueExists(connection, model, exchange, queue);
-            return new RabbitQueueSender(connection, model, confirmMessageSent, exchange, queue);
+            EnsureQueueExists(connection, model, queue);
+            return new RabbitQueueSender(connection, model, confirmMessageSent, string.Empty, queue);
         }
 
         /// <summary>
         /// Creates a new Queue Sender to send encrypted messages
         /// </summary>
-        /// <param name="exchange">The routing exchange to send to</param>
         /// <param name="queue">The queue to send the message to</param>
         /// <param name="username">The username to connect to the queue with</param>
         /// <param name="password">The password to authenticate to the queue with</param>
@@ -157,7 +144,6 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
         /// <param name="encryptionKey">The key used to encrypt the message</param>
         /// <returns>Returns an IQueueSender capable of sending encrypted messages</returns>
         public static IQueueSender CreateSecureSender(
-            string exchange,
             string queue,
             string username,
             string password,
@@ -167,8 +153,8 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
             byte[] encryptionKey)
         {
             CreateRabbitConnection(username, password, virtualHost, host, out IConnection connection, out IModel model);
-            EnsureQueueExists(connection, model, exchange, queue);
-            return new RabbitSecureQueueSender(connection, model, confirmMessageSent, exchange, queue, encryptionKey);
+            EnsureQueueExists(connection, model, queue);
+            return new RabbitSecureQueueSender(connection, model, confirmMessageSent, string.Empty, queue, encryptionKey);
         }
     }
 }


### PR DESCRIPTION
The Exchange variable isn't useful to us right now, so removing it for default implementation