### PR TITLE
Fixing bug where bulk sending would send as one object

### DIFF
--- a/src/Implementations/RabbitMq/RabbitQueueSender.cs
+++ b/src/Implementations/RabbitMq/RabbitQueueSender.cs
@@ -112,7 +112,7 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
 
             foreach (T item in data)
             {
-                byte[] body = await GetMessageContentsAsync(data).ConfigureAwait(false);
+                byte[] body = await GetMessageContentsAsync(item).ConfigureAwait(false);
                 InternalPublishMessage(body);
             }
         }


### PR DESCRIPTION
Fixing bug where RabbitMQ bulk sending would send the whole enumerable as one object instead of as multiple messages with one object each