### PR TITLE
Adding TTL values and NACK support to Rabbit

### DIFF
--- a/src/Abstractions/IQueueBatchListenerTarget.cs
+++ b/src/Abstractions/IQueueBatchListenerTarget.cs
@@ -11,7 +11,7 @@ namespace BaseCap.CloudAbstractions.Abstractions
         /// <summary>
         /// Callback for when Queue Messages have been received
         /// </summary>
-        /// <returns>Returns an awaitable Task</returns>
-        Task OnMessagesReceivedAsync(IEnumerable<QueueMessage> messages);
+        /// <returns>Returns true when the messages are correctly processed; otherwise, returns false</returns>
+        Task<bool> OnMessagesReceivedAsync(IEnumerable<QueueMessage> messages);
     }
 }

--- a/src/Abstractions/IQueueListenerTarget.cs
+++ b/src/Abstractions/IQueueListenerTarget.cs
@@ -10,7 +10,7 @@ namespace BaseCap.CloudAbstractions.Abstractions
         /// <summary>
         /// Callback for when a Queue Message has been received
         /// </summary>
-        /// <returns>Returns an awaitable Task</returns>
-        Task OnMessageReceived(QueueMessage message);
+        /// <returns>Returns true when the messages are correctly processed; otherwise, returns false</returns>
+        Task<bool> OnMessageReceived(QueueMessage message);
     }
 }

--- a/src/Implementations/RabbitMq/RabbitQueueSender.cs
+++ b/src/Implementations/RabbitMq/RabbitQueueSender.cs
@@ -15,6 +15,7 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
     internal class RabbitQueueSender : IQueueSender, IDisposable
     {
         private const int MAX_RETRIES = 10;
+        private readonly string MESSAGE_TTL = TimeSpan.FromHours(12).TotalMilliseconds.ToString();
         private readonly bool _confirmSend;
         private readonly string _exchange;
         private readonly string _queue;
@@ -123,6 +124,7 @@ namespace BaseCap.CloudAbstractions.Implementations.RabbitMq
             bool publishSucceeded = false;
             IBasicProperties props = _model.CreateBasicProperties();
             props.Persistent = true;
+            props.Expiration = MESSAGE_TTL;
 
             do
             {


### PR DESCRIPTION
- Adding message TTL value of 12 hours per-message to Rabbit Messages
- Adding ACK and NACK support to allow message re-delivery