### PR TITLE
Removing references to Logger object

### DIFF
--- a/src/Abstractions/IEmailSender.cs
+++ b/src/Abstractions/IEmailSender.cs
@@ -1,4 +1,3 @@
-using Serilog;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,14 +15,12 @@ namespace BaseCap.CloudAbstractions.Abstractions
         /// <param name="toAddresses">The name/address combination of recipients</param>
         /// <param name="templateId">The ID of the template to send</param>
         /// <param name="templateData">Any object data to be JSON serialized as variables to the template</param>
-        /// <param name="logger">The logger to use for error reporting</param>
         /// <param name="token">A cancellation token to cancel the request</param>
         /// <returns>Returns true if the request was successful; otherwise, returns false</returns>
         Task<bool> SendTemplateEmailAsync<T>(
             IEnumerable<(string email, string name)> toAddresses,
             string templateId,
             T? templateData,
-            ILogger logger,
             CancellationToken token = default(CancellationToken)) where T: class;
     }
 }

--- a/src/Implementations/Azure/AzureEventHub.cs
+++ b/src/Implementations/Azure/AzureEventHub.cs
@@ -17,7 +17,6 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
         private Func<IEnumerable<EventMessage>, string, Task>? _onMessagesReceived;
         private readonly EventHubClient _client;
         private readonly ICheckpointer _checkpointer;
-        private readonly ILogger _logger;
 
         /// <summary>
         /// Creates a new connection with an Azure Event Hub
@@ -25,14 +24,12 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
         public AzureEventHub(
             string eventHubConnectionString,
             string eventHubEntity,
-            ICheckpointer checkpointer,
-            ILogger logger)
+            ICheckpointer checkpointer)
         {
             _readers = new List<AzureEventHubReader>();
             _client = EventHubClient.CreateFromConnectionString(
                 new EventHubsConnectionStringBuilder(eventHubConnectionString) { EntityPath = eventHubEntity }.ToString());
             _checkpointer = checkpointer;
-            _logger = logger;
         }
 
         /// <summary>
@@ -49,7 +46,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
             foreach (string partition in info.PartitionIds)
             {
                 PartitionReceiver receiver = await setupTask(consumerGroup, partition);
-                AzureEventHubReader reader = new AzureEventHubReader(receiver, RefreshPartitionReaderAsync, _onMessagesReceived, _logger);
+                AzureEventHubReader reader = new AzureEventHubReader(receiver, RefreshPartitionReaderAsync, _onMessagesReceived);
                 _readers.Add(reader);
                 reader.Open(token);
             }

--- a/src/Implementations/Azure/AzureEventHubReader.cs
+++ b/src/Implementations/Azure/AzureEventHubReader.cs
@@ -23,7 +23,6 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
         protected Task? _readerTask;
         protected readonly Func<IEnumerable<EventMessage>, string, Task> _onMessagesReceived;
         protected readonly Func<PartitionReceiver, Task<PartitionReceiver>> _receiverRefreshAsync;
-        protected readonly ILogger _logger;
         protected readonly MemoryCache _eventIdCache;
 
         /// <summary>
@@ -32,13 +31,11 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
         internal AzureEventHubReader(
             PartitionReceiver reader,
             Func<PartitionReceiver, Task<PartitionReceiver>> receiverRefresh,
-            Func<IEnumerable<EventMessage>, string, Task> onMessagesReceived,
-            ILogger logger)
+            Func<IEnumerable<EventMessage>, string, Task> onMessagesReceived)
         {
             _reader = reader;
             _receiverRefreshAsync = receiverRefresh;
             _onMessagesReceived = onMessagesReceived;
-            _logger = logger;
             _eventIdCache = new MemoryCache(new MemoryCacheOptions());
         }
 
@@ -89,7 +86,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure
                 {
                     // This usually means a problem with the reader; rebuild it and try again
                     _reader = await _receiverRefreshAsync(_reader);
-                    _logger.Error(sx,"Partition {Partition} on Consumer Group {ConsumerGroup}", _reader.PartitionId, _reader.ConsumerGroupName);
+                    Log.Logger.Error(sx,"Partition {Partition} on Consumer Group {ConsumerGroup}", _reader.PartitionId, _reader.ConsumerGroupName);
                 }
             }
         }

--- a/src/Implementations/Azure/Secure/AzureEncryptedEventHubReader.cs
+++ b/src/Implementations/Azure/Secure/AzureEncryptedEventHubReader.cs
@@ -1,7 +1,6 @@
 using BaseCap.CloudAbstractions.Abstractions;
 using BaseCap.Security;
 using Microsoft.Azure.EventHubs;
-using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -19,9 +18,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Azure.Secure
             PartitionReceiver reader,
             Func<PartitionReceiver, Task<PartitionReceiver>> receiverRefresh,
             Func<IEnumerable<EventMessage>, string, Task> onMessagesReceived,
-            byte[] encryptionKey,
-            ILogger logger)
-            : base(reader, receiverRefresh, onMessagesReceived, logger)
+            byte[] encryptionKey)
+            : base(reader, receiverRefresh, onMessagesReceived)
         {
             _encryptionKey = encryptionKey;
         }

--- a/src/Implementations/Generic/EventCheckpointer.cs
+++ b/src/Implementations/Generic/EventCheckpointer.cs
@@ -1,6 +1,5 @@
 using BaseCap.CloudAbstractions.Abstractions;
 using Serilog;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -13,16 +12,14 @@ namespace BaseCap.CloudAbstractions.Implementations.Generic
     {
         protected readonly IBlobStorage _storage;
         protected readonly string _applicationName;
-        protected readonly ILogger _logger;
 
         /// <summary>
         /// Creates a connection to an application's checkpoint list
         /// </summary>
-        public EventCheckpointer(IBlobStorage storage, string applicationName, ILogger logger)
+        public EventCheckpointer(IBlobStorage storage, string applicationName)
         {
             _storage = storage;
             _applicationName = applicationName;
-            _logger = logger;
         }
 
         private string GetBlobName(string id)
@@ -45,7 +42,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Generic
                 using (StreamReader sr = new StreamReader(blobStream))
                 {
                     value = sr.ReadToEnd()?.Trim();
-                    _logger.Warning("Not Checkpoint Found on Partition {Partition}", id);
+                    Log.Logger.Warning("Not Checkpoint Found on Partition {Partition}", id);
                 }
             }
             catch

--- a/src/Implementations/Redis/RedisBase.cs
+++ b/src/Implementations/Redis/RedisBase.cs
@@ -24,10 +24,9 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         private readonly object _synclock;
         protected readonly string _errorContextName;
         protected readonly string _errorContextValue;
-        protected readonly ILogger _logger;
         private ConnectionMultiplexer? _cacheConnection;
 
-        internal RedisBase(IEnumerable<string> endpoints, string password, bool useSsl, string errorContextName, string errorContextValue, ILogger logger)
+        internal RedisBase(IEnumerable<string> endpoints, string password, bool useSsl, string errorContextName, string errorContextValue)
         {
             if ((endpoints == null) || (endpoints.Any() == false))
             {
@@ -57,10 +56,9 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             };
             _errorContextName = errorContextName;
             _errorContextValue = errorContextValue;
-            _logger = logger;
         }
 
-        internal RedisBase(ConfigurationOptions options, string errorContextName, string errorContextValue, ILogger logger)
+        internal RedisBase(ConfigurationOptions options, string errorContextName, string errorContextValue)
         {
             _synclock = new object();
             _jsonOptions = new JsonSerializerSettings()
@@ -73,7 +71,6 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             _options = options;
             _errorContextName = errorContextName;
             _errorContextValue = errorContextValue;
-            _logger = logger;
         }
 
         protected virtual void Dispose(bool disposing)
@@ -97,7 +94,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         /// <inheritdoc />
         public IHyperLogLog CreateHyperLogLog(string logName)
         {
-            return (IHyperLogLog)new RedisHyperLogLog(logName, _options, _logger);
+            return (IHyperLogLog)new RedisHyperLogLog(logName, _options);
         }
 
         protected void Subscribe(string channel, Action<RedisChannel, RedisValue> handler)
@@ -180,21 +177,21 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
 
         private void OnConnectionFailure(object sender, ConnectionFailedEventArgs e)
         {
-            _logger.Error(e.Exception, "Redis Connection Failure {Type} on {Name} {Context} at Endpoint {Endpoint}", e.FailureType, _errorContextName, _errorContextValue, e.EndPoint);
-            _logger.Warning("Redis Connection Failure at {Name} {Value}", _errorContextName, _errorContextValue);
+            Log.Logger.Error(e.Exception, "Redis Connection Failure {Type} on {Name} {Context} at Endpoint {Endpoint}", e.FailureType, _errorContextName, _errorContextValue, e.EndPoint);
+            Log.Logger.Warning("Redis Connection Failure at {Name} {Value}", _errorContextName, _errorContextValue);
             ConnectionsBroken.Inc();
         }
 
         private void OnConnectionRestored(object sender, ConnectionFailedEventArgs e)
         {
-            _logger.Warning("Redis Connection Restored at {Name} {Value}", _errorContextName, _errorContextValue);
+            Log.Logger.Warning("Redis Connection Restored at {Name} {Value}", _errorContextName, _errorContextValue);
             ConnectionsBroken.Dec();
         }
 
         private void OnRedisInternalError(object sender, InternalErrorEventArgs e)
         {
-            _logger.Error(e.Exception, "Redis Internal Failure: {Type} on {Name} {Context} at {Endpoint}", e.Origin, _errorContextName, _errorContextValue, e.EndPoint);
-            _logger.Warning("Redis Internal Failure at {Name} {Value}", _errorContextName, _errorContextValue);
+            Log.Logger.Error(e.Exception, "Redis Internal Failure: {Type} on {Name} {Context} at {Endpoint}", e.Origin, _errorContextName, _errorContextValue, e.EndPoint);
+            Log.Logger.Warning("Redis Internal Failure at {Name} {Value}", _errorContextName, _errorContextValue);
             InternalErrors.Inc();
         }
 

--- a/src/Implementations/Redis/RedisCache.cs
+++ b/src/Implementations/Redis/RedisCache.cs
@@ -1,5 +1,4 @@
 using BaseCap.CloudAbstractions.Abstractions;
-using Serilog;
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
@@ -17,8 +16,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         /// <summary>
         /// Creates a new RedisCache
         /// </summary>
-        public RedisCache(IEnumerable<string> endpoints, string password, bool useSsl, ILogger logger)
-            : base(endpoints, password, useSsl, "Cache", "[default]", logger)
+        public RedisCache(IEnumerable<string> endpoints, string password, bool useSsl)
+            : base(endpoints, password, useSsl, "Cache", "[default]")
         {
         }
 

--- a/src/Implementations/Redis/RedisHyperLogLog.cs
+++ b/src/Implementations/Redis/RedisHyperLogLog.cs
@@ -1,5 +1,4 @@
 using BaseCap.CloudAbstractions.Abstractions;
-using Serilog;
 using StackExchange.Redis;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -16,14 +15,14 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         /// <summary>
         /// Creates a new RedisHyperLogLog
         /// </summary>
-        public RedisHyperLogLog(IEnumerable<string> endpoints, string password, string logName, bool useSsl, ILogger logger)
-            : base(endpoints, password, useSsl, "HyperLogLog", "[default]", logger)
+        public RedisHyperLogLog(IEnumerable<string> endpoints, string password, string logName, bool useSsl)
+            : base(endpoints, password, useSsl, "HyperLogLog", "[default]")
         {
             _logName = logName;
         }
 
-        internal RedisHyperLogLog(string logName, ConfigurationOptions options, ILogger logger)
-            : base(options, "HyperLogLog", "[default]", logger)
+        internal RedisHyperLogLog(string logName, ConfigurationOptions options)
+            : base(options, "HyperLogLog", "[default]")
         {
             _logName = logName;
         }

--- a/src/Implementations/Redis/RedisPubSubReceiver.cs
+++ b/src/Implementations/Redis/RedisPubSubReceiver.cs
@@ -1,5 +1,4 @@
 using BaseCap.CloudAbstractions.Abstractions;
-using Serilog;
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
@@ -15,8 +14,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         protected readonly string _channel;
         private Func<string, Task>? _handler;
 
-        public RedisPubSubReceiver(IEnumerable<string> endpoints, string password, string channel, bool useSsl, ILogger logger)
-            : base(endpoints, password, useSsl, "Channel", channel, logger)
+        public RedisPubSubReceiver(IEnumerable<string> endpoints, string password, string channel, bool useSsl)
+            : base(endpoints, password, useSsl, "Channel", channel)
         {
             _channel = channel;
         }

--- a/src/Implementations/Redis/RedisPubSubSender.cs
+++ b/src/Implementations/Redis/RedisPubSubSender.cs
@@ -1,5 +1,4 @@
 using BaseCap.CloudAbstractions.Abstractions;
-using Serilog;
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
@@ -14,8 +13,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
     {
         private readonly string _channel;
 
-        public RedisPubSubSender(IEnumerable<string> endpoints, string password, string channel, bool useSsl, ILogger logger)
-            : base(endpoints, password, useSsl, "Channel", channel, logger)
+        public RedisPubSubSender(IEnumerable<string> endpoints, string password, string channel, bool useSsl)
+            : base(endpoints, password, useSsl, "Channel", channel)
         {
             _channel = channel;
         }

--- a/src/Implementations/Redis/RedisQueueStorage.cs
+++ b/src/Implementations/Redis/RedisQueueStorage.cs
@@ -28,8 +28,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
         /// <summary>
         /// Creates a new connection to an Azure Queue Storage
         /// </summary>
-        public RedisQueueStorage(IEnumerable<string> endpoints, string password, string queueName, bool useSsl, ILogger logger)
-            : base(endpoints, password, useSsl, "QueueName", queueName, logger)
+        public RedisQueueStorage(IEnumerable<string> endpoints, string password, string queueName, bool useSsl)
+            : base(endpoints, password, useSsl, "QueueName", queueName)
         {
             _queueName = queueName;
             _channelName = $"{_queueName}{CHANNEL_SUFFIX}";
@@ -71,7 +71,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, "Redis Queue Polling Error");
+                    Log.Logger.Error(ex, "Redis Queue Polling Error");
                 }
             }
         }
@@ -114,7 +114,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
                     ISubscriber sub = GetSubscriber();
                     await db.ListLeftPushAsync(DEADLETTER_QUEUE, processingMsg).ConfigureAwait(false);
                     await sub.PublishAsync(DEADLETTER_CHANNEL, "").ConfigureAwait(false);
-                    _logger.Warning("Redis Queue {QueueName} Deadletter: {Message}", _queueName, processingMsg);
+                    Log.Logger.Warning("Redis Queue {QueueName} Deadletter: {Message}", _queueName, processingMsg);
                     DeadletterCounter.Inc();
                     return;
                 }
@@ -132,7 +132,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             }
             catch
             {
-                _logger.Warning("Redis Queue {QueueName} Unhandled Message: {Message}", _queueName, message);
+                Log.Logger.Warning("Redis Queue {QueueName} Unhandled Message: {Message}", _queueName, message);
                 UnhandledMessageCount.Inc();
             }
         }

--- a/src/Implementations/Redis/RedisStreamReader.cs
+++ b/src/Implementations/Redis/RedisStreamReader.cs
@@ -29,30 +29,26 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             bool useSsl,
             string streamName,
             string consumerGroup,
-            string consumerName,
-            ILogger logger)
-            : base(endpoints, password, useSsl, "EventStreamReader", $"{streamName}.{consumerGroup}:{consumerName}", logger)
+            string consumerName)
+            : base(endpoints, password, useSsl, "EventStreamReader", $"{streamName}.{consumerGroup}:{consumerName}")
         {
             if ((endpoints == null) || (endpoints.Any() == false) || (endpoints.Any(e => string.IsNullOrWhiteSpace(e))))
             {
                 throw new ArgumentNullException(nameof(endpoints));
             }
-            if (string.IsNullOrWhiteSpace(streamName))
+            else if (string.IsNullOrWhiteSpace(streamName))
             {
                 throw new ArgumentNullException(nameof(streamName));
             }
-            if (string.IsNullOrWhiteSpace(consumerGroup))
+            else if (string.IsNullOrWhiteSpace(consumerGroup))
             {
                 throw new ArgumentNullException(nameof(consumerGroup));
             }
-            if (string.IsNullOrWhiteSpace(consumerName))
+            else if (string.IsNullOrWhiteSpace(consumerName))
             {
                 throw new ArgumentNullException(nameof(consumerName));
             }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+
             _streamName = streamName;
             _consumerGroup = consumerGroup;
             _consumerName = consumerName;
@@ -63,26 +59,22 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             string password,
             bool useSsl,
             string streamName,
-            string consumerName,
-            ILogger logger)
-            : base(endpoints, password, useSsl, "EventStreamReader-NonGroup", $"{streamName}:{consumerName}", logger)
+            string consumerName)
+            : base(endpoints, password, useSsl, "EventStreamReader-NonGroup", $"{streamName}:{consumerName}")
         {
             if ((endpoints == null) || (endpoints.Any() == false) || (endpoints.Any(e => string.IsNullOrWhiteSpace(e))))
             {
                 throw new ArgumentNullException(nameof(endpoints));
             }
-            if (string.IsNullOrWhiteSpace(streamName))
+            else if (string.IsNullOrWhiteSpace(streamName))
             {
                 throw new ArgumentNullException(nameof(streamName));
             }
-            if (string.IsNullOrWhiteSpace(consumerName))
+            else if (string.IsNullOrWhiteSpace(consumerName))
             {
                 throw new ArgumentNullException(nameof(consumerName));
             }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+
             _streamName = streamName;
             _consumerGroup = string.Empty;
             _consumerName = consumerName;
@@ -157,7 +149,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Error on Stream {Name} Group {Group} Consumer {Consumer}", _streamName, _consumerGroup, _consumerName);
+                Log.Logger.Error(ex, "Error on Stream {Name} Group {Group} Consumer {Consumer}", _streamName, _consumerGroup, _consumerName);
                 UnhandledError.Inc();
 
                 throw;

--- a/src/Implementations/Redis/RedisStreamSender.cs
+++ b/src/Implementations/Redis/RedisStreamSender.cs
@@ -1,5 +1,4 @@
 using BaseCap.CloudAbstractions.Abstractions;
-using Serilog;
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
@@ -20,9 +19,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis
             IEnumerable<string> endpoints,
             string password,
             bool useSsl,
-            string streamName,
-            ILogger logger)
-            : base(endpoints, password, useSsl, "EventStreamWriter", $"{streamName}", logger)
+            string streamName)
+            : base(endpoints, password, useSsl, "EventStreamWriter", $"{streamName}")
         {
             _streamName = streamName;
         }

--- a/src/Implementations/Redis/Secure/EncryptedRedisCache.cs
+++ b/src/Implementations/Redis/Secure/EncryptedRedisCache.cs
@@ -1,5 +1,4 @@
 using BaseCap.Security;
-using Prometheus;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -14,8 +13,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
     {
         private byte[] _encryptionKey;
 
-        public EncryptedRedisCache(IEnumerable<string> endpoints, string password, bool useSsl, byte[] encryptionKey, ILogger logger)
-            : base(endpoints, password, useSsl, logger)
+        public EncryptedRedisCache(IEnumerable<string> endpoints, string password, bool useSsl, byte[] encryptionKey)
+            : base(endpoints, password, useSsl)
         {
             _encryptionKey = encryptionKey;
         }
@@ -39,7 +38,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed decrypting {Value}", value);
+                Log.Logger.Error(ex, "Failed decrypting {Value}", value);
                 DecryptFailures.Inc();
 
 #nullable disable // Nullable doesn't work with generics and default

--- a/src/Implementations/Redis/Secure/EncryptedRedisPubSubReceiver.cs
+++ b/src/Implementations/Redis/Secure/EncryptedRedisPubSubReceiver.cs
@@ -19,9 +19,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             IEnumerable<string> endpoints,
             string password,
             string channel,
-            bool useSsl,
-            ILogger logger)
-            : base(endpoints, password, channel, useSsl, logger)
+            bool useSsl)
+            : base(endpoints, password, channel, useSsl)
         {
             _encryptionKey = encryptionKey;
         }
@@ -38,7 +37,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed decrypting on Channel {Channel}: {Value}", _channel, value);
+                Log.Logger.Error(ex, "Failed decrypting on Channel {Channel}: {Value}", _channel, value);
                 DecryptFailures.Inc();
             }
         }

--- a/src/Implementations/Redis/Secure/EncryptedRedisPubSubSender.cs
+++ b/src/Implementations/Redis/Secure/EncryptedRedisPubSubSender.cs
@@ -18,9 +18,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             IEnumerable<string> endpoints,
             string password,
             string channel,
-            bool useSsl,
-            ILogger logger)
-            : base(endpoints, password, channel, useSsl, logger)
+            bool useSsl)
+            : base(endpoints, password, channel, useSsl)
         {
             _encryptionKey = encryptionKey;
         }
@@ -36,7 +35,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed encrypting {@Value}", notification);
+                Log.Logger.Error(ex, "Failed encrypting {@Value}", notification);
                 DecryptFailures.Inc();
                 throw;
             }

--- a/src/Implementations/Redis/Secure/EncryptedRedisQueueStorage.cs
+++ b/src/Implementations/Redis/Secure/EncryptedRedisQueueStorage.cs
@@ -19,8 +19,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
         /// <summary>
         /// Creates a new connection to a Azure Queue Storage container with a given encryption key
         /// </summary>
-        public EncryptedRedisQueueStorage(IEnumerable<string> endpoints, string password, string queueName, bool useSsl, byte[] encryptionKey, ILogger logger)
-            : base(endpoints, password, queueName, useSsl, logger)
+        public EncryptedRedisQueueStorage(IEnumerable<string> endpoints, string password, string queueName, bool useSsl, byte[] encryptionKey)
+            : base(endpoints, password, queueName, useSsl)
         {
             _encryptionKey = encryptionKey;
         }
@@ -49,7 +49,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed decrypting on Queue {Name}: {Value}", _queueName, message);
+                Log.Logger.Error(ex, "Failed decrypting on Queue {Name}: {Value}", _queueName, message);
                 DecryptFailures.Inc();
             }
         }

--- a/src/Implementations/Redis/Secure/EncryptedRedisStreamReader.cs
+++ b/src/Implementations/Redis/Secure/EncryptedRedisStreamReader.cs
@@ -24,9 +24,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             bool useSsl,
             string streamName,
             string consumerGroup,
-            string consumerName,
-            ILogger logger)
-            : base(endpoints, password, useSsl, streamName, consumerGroup, consumerName, logger)
+            string consumerName)
+            : base(endpoints, password, useSsl, streamName, consumerGroup, consumerName)
         {
             _encryptionKey = encryptionKey;
         }
@@ -38,9 +37,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             string password,
             bool useSsl,
             string streamName,
-            string consumerName,
-            ILogger logger)
-            : base(endpoints, password, useSsl, streamName, consumerName, logger)
+            string consumerName)
+            : base(endpoints, password, useSsl, streamName, consumerName)
         {
             _encryptionKey = encryptionKey;
         }
@@ -61,7 +59,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(
+                    Log.Logger.Error(
                         ex,
                         "Failed decrypting on Stream {Name} Consumer Group {Group} Consumer {Consumer} at {Offset}-{Sequence}: {Value}",
                         _streamName,

--- a/src/Implementations/Redis/Secure/EncryptedRedisStreamSender.cs
+++ b/src/Implementations/Redis/Secure/EncryptedRedisStreamSender.cs
@@ -18,9 +18,8 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             IEnumerable<string> endpoints,
             string password,
             bool useSsl,
-            string streamName,
-            ILogger logger)
-            : base(endpoints, password, useSsl, streamName, logger)
+            string streamName)
+            : base(endpoints, password, useSsl, streamName)
         {
             _encryptionKey = encryptionKey;
         }
@@ -36,7 +35,7 @@ namespace BaseCap.CloudAbstractions.Implementations.Redis.Secure
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed encrypting {@Value}", obj);
+                Log.Logger.Error(ex, "Failed encrypting {@Value}", obj);
                 DecryptFailures.Inc();
                 throw;
             }

--- a/src/Implementations/SendGrid/SendGridEmailSender.cs
+++ b/src/Implementations/SendGrid/SendGridEmailSender.cs
@@ -44,7 +44,6 @@ namespace BaseCap.CloudAbstractions.Implementations.SendGrid
             IEnumerable<(string email, string name)> toAddresses,
             string templateId,
             T? templateData,
-            ILogger logger,
             CancellationToken token = default(CancellationToken)) where T : class
         {
             SendGridMessage msg = new SendGridMessage();
@@ -65,7 +64,7 @@ namespace BaseCap.CloudAbstractions.Implementations.SendGrid
             }
             else
             {
-                logger.Error("Failed to fire SendGrid Email {TemplateId} to {Count} with Error Code {Error}", templateId, toAddresses.Count(), resp.StatusCode);
+                Log.Logger.Error("Failed to fire SendGrid Email {TemplateId} to {Count} with Error Code {Error}", templateId, toAddresses.Count(), resp.StatusCode);
                 return false;
             }
         }


### PR DESCRIPTION
Removing object-instance reference to Logger and using static logger instead for cleaner calls